### PR TITLE
Updated Dockerfile to install percli from npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM adoptopenjdk:8-jdk-hotspot
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
     && apt -y install git maven nano nodejs \ 
     && rm -rf /var/lib/apt/lists/* \
+    && npm install percli -g \
     && sed -i 's|</settings>|<localRepository>/peregrine/.m2/repository</localRepository></settings>|' /etc/maven/settings.xml
 
 RUN mkdir -p /opt/scripts


### PR DESCRIPTION
It's useful to have percli on the command line when doing work with peregrine. This will install percli globally through npm so that it is available in the container for command line usage.